### PR TITLE
a11y readme

### DIFF
--- a/ws-rcf/README.md
+++ b/ws-rcf/README.md
@@ -25,13 +25,62 @@ Un cop emplenat el token, aquest s'haurà de signar amb l'algorisme HMAC-SHA256,
 
 A continuació, es mostra un exemple de token JWT en clar, abans de codificar a Base64:
 
-![imagen](https://github.com/ConsorciAOC/eFact/assets/92558339/c5f67b58-363b-43e1-a1fe-6d15d778f1fa)
+![A continuació hi ha un desplegable amb l'explicació de descripció de la imatge](https://github.com/ConsorciAOC/eFact/assets/92558339/c5f67b58-363b-43e1-a1fe-6d15d778f1fa)
 
+<details>
+  <summary><i>Explicació textual de la imatge</i></summary>
+
+### SEGMENT I
+L'algorisme de signatura emprat per protegir el token, així com el tipus de token. Només es suportarà l'algoritme HS256 i el tipus de token JWT.
+
+```json
+{
+    "alg": "HS256",
+    "typ": "JWT"
+}
+```
+
+### SEGMENT II
+Dades d'autenticació i autorització comentades anteriorment.
+
+```json
+{
+    "iss": "hub_0012",
+    "aud": "efact",
+    "iat": 1516239022,
+    "nbf": 1516239022,
+    "exp": 1516239042
+}
+```
+
+### SEGMENT III
+Signatura del token, necessària per verificar que no ha estat alterat, així com la seva autenticitat.
+
+```
+3oGx4zGJy7YfYTIiBiPNBPCUGrC8oNlKQaGHSO4D5M0
+```
+
+### Notes
+
+Els segments van delimitats per punts, de manera que trobem el primer segment, un punt, el segon segment, un punt i el tercer segment.
+
+</details>
 
 Un cop generat el token, aquest s'inclourà a la capçalera HTTP 'Authorization' de la següent manera:
 
-Authorization: Bearer 
-![imagen](https://github.com/ConsorciAOC/eFact/assets/92558339/5faf7b0f-22ac-4f6f-96ba-1cbc0a9c86ef)
+![A continuació hi ha un desplegable amb l'explicació de descripció de la imatge](https://github.com/ConsorciAOC/eFact/assets/92558339/5faf7b0f-22ac-4f6f-96ba-1cbc0a9c86ef)
+
+<details>
+  <summary><i>Explicació textual de la imatge</i></summary>
+
+La cadena que hi ha a continuació és una concatenació dels tres segments un cop codificat a Base64
+
+```
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJBUFawMDAxIiwic3ViIjoiOTgyMTkyMDAwMiIsInVzZXIiOiIxMTExMTEwMTExMUgiLCJvYW1pIjoiSm9zZXZA9zZXAgSm9zZXAgSm9zZXAiOjE1MTYyMzkwMjIsIm5iZiI6MTUxMTUxOTAyMiwiZXhwIjoxNTE2MjM5MDQyfQ.3oGx4zGJy7YfYTIiBiPNBPCUGrC8oNlKQaGHSO4D5M0
+```
+
+
+</details>
 
 A l'exemple de capçalera HTTP amb el token JWT es mostren els diferents segments del token pintats de diferent color. Com es pot observar, els segments estan separats per un punt.
 


### PR DESCRIPTION
El readme conté imatges sense descripció. Això és un inconvenient per aquelles persones que utilitzen lector de pantalla.

Com que la descripció és llarga, en comptes de descripció es proposa un desplegable amb l'explicació de la imatge.

En qualsevol cas, al meu entendre, seria ideal substituir les imatges per text. Aquesta PR no ho fa per respectar la feina actual, però, si ho considereu oportú, puc modificar la PR per eliminar imatges i deixar només els textos.