### PR TITLE
Fixar esquema resposta error

### DIFF
--- a/ws-rcf/README.md
+++ b/ws-rcf/README.md
@@ -101,8 +101,8 @@ En cas d'error, el servei tornarà un fitxer de tipus `application/json` amb el 
 
 ```json
 {
-	"codiError": "9999",
-	"descripcioError": "descripcio error" 
+	"errorCode": 9999,
+	"errorInfo": "descripció error" 
 }
 ```
 


### PR DESCRIPTION
Closes #5 

L'esquema del json corresponent a les respostes d'error és diferent del documentat:
* Les etiquetes són diferents.
* El codi d'error retornat és numèric (i no cadena).

En aquesta PR es fixa la documentació per tal que tingui l'esquema correcte.